### PR TITLE
cargo: bump version-sync dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,6 @@ edition = "2018"
 
 [dependencies]
 regex = "1.1.0"
-version-sync = "0.7"
+
+[dev-dependencies]
+version-sync = "0.8"


### PR DESCRIPTION
The new version 0.8.0 requires Rust 2018, which this project is already using. This change also changes the dependency to a dev-dependency since the crate is only necessary for running tests.